### PR TITLE
Fix toc for cohort 3 lecture 5

### DIFF
--- a/docs/Lectures/Cohort_03/Lecture_05.md
+++ b/docs/Lectures/Cohort_03/Lecture_05.md
@@ -13,13 +13,15 @@ Google Doc version can be found [HERE](https://docs.google.com/document/d/1o89UQ
 
 ## Table of Contents
 
-1. [Preparation for Lecture 5](#Preparation-for-Lecture-5)
-2. [Values](#Values)
-3. [A Simple Minting Policy](#A-Simple-Minting-Policy)
-4. [A More Realistic Minting Policy](#A-More-Realistic-Minting-Policy)
-5. [NFT’s](#NFT's)
-6. [Homework Part 1](#Homework-Part-1)
-7. [Homework Part 2](#Homework-Part-2)
+- [Lecture 5: Minting Tokens and NFTS](#lecture-5-minting-tokens-and-nfts)
+  - [Table of Contents](#table-of-contents)
+  - [Preparation for Lecture 5](#preparation-for-lecture-5)
+  - [Values](#values)
+  - [A Simple Minting Policy](#a-simple-minting-policy)
+  - [A More Realistic Minting Policy](#a-more-realistic-minting-policy)
+  - [NFT’s](#nfts)
+  - [Homework Part 1](#homework-part-1)
+  - [Homework Part 2](#homework-part-2)
 
 ## Preparation for Lecture 5
 


### PR DESCRIPTION
The links here work:
![Screenshot from 2022-02-14 21-02-32](https://user-images.githubusercontent.com/29824802/153894279-a026b093-2efc-49cd-9a44-f96110e5546e.png)
But these don't:
![Screenshot from 2022-02-14 21-02-59](https://user-images.githubusercontent.com/29824802/153894378-a63f759c-24a2-40c9-b7bf-f900d44d3b97.png)

the only difference is the first letter being lowercase (after the hash).

I used this extension to fix this automatically: [yzhang.markdown-all-in-one](https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one).