### PR TITLE
Update CurrencySymbol

### DIFF
--- a/docs/Lectures/Cohort_03/Lecture_05.md
+++ b/docs/Lectures/Cohort_03/Lecture_05.md
@@ -99,7 +99,14 @@ Value
 getValue :: Map CurrencySymbol (Map TokenName Integer)	 
 ```
 
-Each native token, including ADA, is represented by a currency symbol and token name. Where currency symbol is:
+Each native token, including ADA, is represented by a currency symbol and token name. 
+
+Where currency symbol is:
+
+```haskell
+CurrencySymbol	 
+unCurrencySymbol :: BuiltinByteString
+```
 
 Token name is:
 


### PR DESCRIPTION
Copy paste error from the original doc, missing:

CurrencySymbol	 
unCurrencySymbol :: BuiltinByteString

Now corrected